### PR TITLE
Update alpine to 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,15 @@ RUN apk --update add bash curl ca-certificates && \
     rm -rf /tmp/glibc-2.26-r0.apk /var/cache/apk/*
 
 # Add the s6 overlay.
-ENV S6_VERSION v1.19.1.1
+ENV S6_VERSION=v1.21.2.2 \
+    # If any script in `fix-attrs` or `cont-init` fails it will warn but continue.
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=1 \
+    # Instruct fix-attrs.d scripts to apply to hidden files and directories.
+    # Set to 0 to skip processing hidden files.
+    S6_FIX_ATTRS_HIDDEN=1
+
 RUN curl -L "https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-amd64.tar.gz" | \
     tar xzvf - -C /
-ENV S6_BEHAVIOUR_IF_STAGE2_FAILS 1
 
 # Run the s6-based init.
 ENTRYPOINT ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.7
 
 RUN apk --update add bash curl ca-certificates && \
     curl -Ls https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub > /etc/apk/keys/sgerrand.rsa.pub && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.7
 
 RUN apk --update add bash curl ca-certificates && \
     curl -Ls https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub > /etc/apk/keys/sgerrand.rsa.pub && \
-    curl -Ls https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk > /tmp/glibc-2.25-r0.apk && \
-    apk add --allow-untrusted /tmp/glibc-2.25-r0.apk && \
-    rm -rf /tmp/glibc-2.25-r0.apk /var/cache/apk/*
+    curl -Ls https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk > /tmp/glibc-2.26-r0.apk && \
+    apk add /tmp/glibc-2.26-r0.apk && \
+    rm -rf /tmp/glibc-2.26-r0.apk /var/cache/apk/*
 
 # Add the s6 overlay.
 ENV S6_VERSION v1.19.1.1

--- a/README.md
+++ b/README.md
@@ -21,17 +21,10 @@ with them, please [see the documentation](http://docs.outrigger.sh/en/latest/).
 All images derived from Service Base (Light) use the [S6 init system](https://github.com/just-containers/s6-overlay)
 for more sophisticated process management.
 
-### confd
-
-S6 is used to trigger [confd](https://github.com/kelseyhightower/confd) templating
-of environment configurations. Service Base itself does not make significant use
-of these templates, but Docker images extending from this may use it to create
-configurable configuration using environment variables.
-
 ## Security Reports
 
 Please email outrigger@phase2technology.com with security concerns.
 
 ## Maintainers
 
-[![Phase2 Logo](https://www.phase2technology.com/wp-content/uploads/2015/06/logo-retina.png)](https://www.phase2technology.com)
+[![Phase2 Logo](https://s3.amazonaws.com/phase2.public/logos/phase2-logo.png)](https://www.phase2technology.com)


### PR DESCRIPTION
Tried to keep the commits separate and clean. Alpine 3.6 required the upgrade to glibc, I see nothing in the issue queue for glibc indicating that Alpine 3.7 is an issue. 3.7 is latest stable release.

Amongst other things, this bumps the version of many Alpine packages, including getting nginx up to 1.12.

I started putting this together because I wanted to add confd and nginx, but the official nginx image looks more comprehensive anyway so I'm thinking I might manage it by adding confd to that instead.